### PR TITLE
Fixing end date

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ country: United-States
 humandate: Jan 15-16, 2015
 humantime: 9:00 am - 5 pm
 startdate: 2015-01-15
-enddate: 2015-01-016
+enddate: 2015-01-16
 latlng: 42.448938, -76.476148
 registration: restricted
 instructor: ["Erika Mudrak (CSCU)", "Jeramia Ory (Kings College)", "Emily Davenport (Cornell University)"]


### PR DESCRIPTION
Fixing end date of workshop by removing extraneous 0 so that the main web site can parse it and add this one to the calendar.
